### PR TITLE
fix:修复在非鸿蒙系统平台报错

### DIFF
--- a/src/UdpSocket.js
+++ b/src/UdpSocket.js
@@ -1,7 +1,8 @@
 import { EventEmitter } from 'events'
 import { Buffer } from 'buffer'
-import { DeviceEventEmitter, NativeModules } from 'react-native'
-const Sockets = TurboModuleRegistry ? TurboModuleRegistry.get('ReactNativeUdpSockets') : NativeModules.UdpSockets;
+import { DeviceEventEmitter, NativeModules, TurboModuleRegistry, Platform } from 'react-native'
+const isHarmony = Platform.OS === 'harmony';
+const Sockets = isHarmony ? TurboModuleRegistry.get('ReactNativeUdpSockets'):NativeModules.UdpSockets
 import normalizeBindOptions from './normalizeBindOptions'
 let instances = 0
 const STATE = {


### PR DESCRIPTION
# Summary
 此次提交修改是为修复创建udp在非鸿蒙系统平台报错。close #6

## Test Plant

![Screenshot_2024-08-28T110953](https://github.com/user-attachments/assets/458f981e-6514-4b27-9c48-1802c6251bd9)


## Checklist
<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [X] 已经添加了对应 API 的测试用例
- [ ] 已经更新了文档
- [X] 更新了 JS/TS 代码