### PR TITLE
fix: client关闭后执行send方法异常崩溃问题修复

### DIFF
--- a/harmony/react_native_udp/src/main/ets/RNUdpTurboModule.ts
+++ b/harmony/react_native_udp/src/main/ets/RNUdpTurboModule.ts
@@ -131,9 +131,6 @@ export class RNUdpTurboModule extends TurboModule implements TM.ReactNativeUdpSo
                 }
             });
         }
-        // else {
-        //     callback("updClient is null");
-        // }
     }
 
     setBroadcast(cId: number, flag: boolean, callback: (err: string | Object | null) => void): void {

--- a/harmony/react_native_udp/src/main/ets/RNUdpTurboModule.ts
+++ b/harmony/react_native_udp/src/main/ets/RNUdpTurboModule.ts
@@ -51,7 +51,7 @@ export class RNUdpTurboModule extends TurboModule implements TM.ReactNativeUdpSo
         address: string;
         port: number;
     }) => void): void {
-        let client: socket.MulticastSocket = this.findClient(cId, callback);
+        let client: socket.MulticastSocket = this.findClient(cId);
         if (client == null) {
             callback("udp client not exist", {
                 address: addressStr,
@@ -131,9 +131,9 @@ export class RNUdpTurboModule extends TurboModule implements TM.ReactNativeUdpSo
                 }
             });
         }
-        else {
-            callback("updClient is null");
-        }
+        // else {
+        //     callback("updClient is null");
+        // }
     }
 
     setBroadcast(cId: number, flag: boolean, callback: (err: string | Object | null) => void): void {
@@ -224,6 +224,7 @@ export class RNUdpTurboModule extends TurboModule implements TM.ReactNativeUdpSo
             if (callback) {
                 const errorMessage = "UdpError there is no upd ";
                 callback(errorMessage);
+                return ;
             }
         }
         return client;


### PR DESCRIPTION
arkjs一次执行流只允许执行一次回调，重复调起回调函数会导致程序崩溃。
本次修改在findClient函数内callback执行后return，避免后续流程继续使用callback函数引发上述问题。